### PR TITLE
feat: Discord チャンネルメッセージ取得機能を追加

### DIFF
--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
-import { DiscordGuild, DiscordApiError, DiscordBotUser, DiscordGuildDetailed, DiscordChannel, DiscordGuildMember } from '../types/discord.js';
+import { DiscordGuild, DiscordApiError, DiscordBotUser, DiscordGuildDetailed, DiscordChannel, DiscordGuildMember, DiscordMessage } from '../types/discord.js';
 
 /**
  * Discord REST API クライアント
@@ -105,6 +105,38 @@ export class DiscordClient {
       }
 
       const response = await this.http.get(`/guilds/${guildId}/members?${params.toString()}`);
+      return response.data;
+    } catch (error) {
+      this.handleApiError(error as AxiosError);
+      throw error;
+    }
+  }
+
+  /**
+   * 特定のチャンネルのメッセージ一覧を取得
+   */
+  async getChannelMessages(channelId: string, options?: {
+    limit?: number;
+    before?: string;
+    after?: string;
+    around?: string;
+  }): Promise<DiscordMessage[]> {
+    try {
+      const params = new URLSearchParams();
+      if (options?.limit) {
+        params.append('limit', Math.min(options.limit, 100).toString());
+      }
+      if (options?.before) {
+        params.append('before', options.before);
+      }
+      if (options?.after) {
+        params.append('after', options.after);
+      }
+      if (options?.around) {
+        params.append('around', options.around);
+      }
+
+      const response = await this.http.get(`/channels/${channelId}/messages?${params.toString()}`);
       return response.data;
     } catch (error) {
       this.handleApiError(error as AxiosError);

--- a/src/tools/get-channel-messages.test.ts
+++ b/src/tools/get-channel-messages.test.ts
@@ -1,0 +1,239 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordClient } from '../discord/client.js';
+import { getChannelMessages, GetChannelMessagesInputSchema } from './get-channel-messages.js';
+import { DiscordMessage } from '../types/discord.js';
+
+// DiscordClientのモック
+vi.mock('../discord/client.js');
+
+describe('getChannelMessages', () => {
+  let mockDiscordClient: vi.Mocked<DiscordClient>;
+
+  beforeEach(() => {
+    mockDiscordClient = {
+      getChannelMessages: vi.fn(),
+    } as any;
+  });
+
+  const mockMessage: DiscordMessage = {
+    id: '123456789',
+    channel_id: '987654321',
+    guild_id: '555666777',
+    author: {
+      id: '111222333',
+      username: 'testuser',
+      discriminator: '1234',
+      avatar: 'avatar_hash',
+      bot: false
+    },
+    content: 'Hello, world!',
+    timestamp: '2023-01-01T00:00:00.000Z',
+    edited_timestamp: null,
+    tts: false,
+    mention_everyone: false,
+    mentions: [],
+    mention_roles: [],
+    attachments: [],
+    embeds: [],
+    reactions: [],
+    type: 0,
+    flags: 0,
+    pinned: false
+  };
+
+  describe('正常系', () => {
+    it('チャンネルのメッセージ一覧を取得できる', async () => {
+      mockDiscordClient.getChannelMessages.mockResolvedValue([mockMessage]);
+
+      const input = {
+        channelId: '987654321',
+        limit: 50
+      };
+
+      const result = await getChannelMessages(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getChannelMessages).toHaveBeenCalledWith('987654321', {
+        limit: 50
+      });
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].id).toBe('123456789');
+      expect(result.messages[0].content).toBe('Hello, world!');
+      expect(result.totalCount).toBe(1);
+    });
+
+    it('limitパラメータなしでデフォルト値が使用される', async () => {
+      mockDiscordClient.getChannelMessages.mockResolvedValue([mockMessage]);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      const result = await getChannelMessages(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getChannelMessages).toHaveBeenCalledWith('987654321', {
+        limit: 50
+      });
+      expect(result.messages).toHaveLength(1);
+    });
+
+    it('beforeパラメータを指定してメッセージを取得できる', async () => {
+      mockDiscordClient.getChannelMessages.mockResolvedValue([mockMessage]);
+
+      const input = {
+        channelId: '987654321',
+        limit: 25,
+        before: '999888777'
+      };
+
+      const result = await getChannelMessages(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getChannelMessages).toHaveBeenCalledWith('987654321', {
+        limit: 25,
+        before: '999888777'
+      });
+    });
+
+    it('afterパラメータを指定してメッセージを取得できる', async () => {
+      mockDiscordClient.getChannelMessages.mockResolvedValue([mockMessage]);
+
+      const input = {
+        channelId: '987654321',
+        limit: 25,
+        after: '111222333'
+      };
+
+      const result = await getChannelMessages(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getChannelMessages).toHaveBeenCalledWith('987654321', {
+        limit: 25,
+        after: '111222333'
+      });
+    });
+
+    it('aroundパラメータを指定してメッセージを取得できる', async () => {
+      mockDiscordClient.getChannelMessages.mockResolvedValue([mockMessage]);
+
+      const input = {
+        channelId: '987654321',
+        limit: 25,
+        around: '444555666'
+      };
+
+      const result = await getChannelMessages(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getChannelMessages).toHaveBeenCalledWith('987654321', {
+        limit: 25,
+        around: '444555666'
+      });
+    });
+
+    it('空のメッセージリストを取得できる', async () => {
+      mockDiscordClient.getChannelMessages.mockResolvedValue([]);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      const result = await getChannelMessages(mockDiscordClient, input);
+
+      expect(result.messages).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+    });
+  });
+
+  describe('異常系', () => {
+    it('Discord APIエラーが発生した場合、適切なエラーメッセージを返す', async () => {
+      const apiError = new Error('Discord API Error: 403 Forbidden');
+      mockDiscordClient.getChannelMessages.mockRejectedValue(apiError);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      await expect(getChannelMessages(mockDiscordClient, input)).rejects.toThrow(
+        'チャンネルメッセージの取得に失敗しました: Discord API Error: 403 Forbidden'
+      );
+    });
+
+    it('不明なエラーが発生した場合、汎用エラーメッセージを返す', async () => {
+      mockDiscordClient.getChannelMessages.mockRejectedValue(null);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      await expect(getChannelMessages(mockDiscordClient, input)).rejects.toThrow(
+        'チャンネルメッセージの取得に失敗しました: チャンネルメッセージの取得中に不明なエラーが発生しました'
+      );
+    });
+  });
+
+  describe('入力バリデーション', () => {
+    it('有効な入力値を正常に検証する', () => {
+      const validInput = {
+        channelId: '123456789',
+        limit: 25,
+        before: '987654321'
+      };
+
+      const result = GetChannelMessagesInputSchema.safeParse(validInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.channelId).toBe('123456789');
+      }
+    });
+
+    it('channelIdが空文字の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        channelId: '',
+        limit: 25
+      };
+
+      const result = GetChannelMessagesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('limitが範囲外の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        channelId: '123456789',
+        limit: 101
+      };
+
+      const result = GetChannelMessagesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('limitが0以下の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        channelId: '123456789',
+        limit: 0
+      };
+
+      const result = GetChannelMessagesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('複数のページネーションパラメータが指定された場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        channelId: '123456789',
+        before: '111',
+        after: '222'
+      };
+
+      const result = GetChannelMessagesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/tools/get-channel-messages.ts
+++ b/src/tools/get-channel-messages.ts
@@ -1,0 +1,228 @@
+import { z } from 'zod';
+import { DiscordClient } from '../discord/client.js';
+
+/**
+ * チャンネルメッセージ取得ツールの入力スキーマ
+ */
+export const GetChannelMessagesInputSchema = z.object({
+  /** チャンネルID（必須） */
+  channelId: z.string().min(1, 'チャンネルIDは必須です'),
+  /** 取得する最大数（オプション、デフォルト: 50、最大: 100） */
+  limit: z.number().min(1).max(100).optional().default(50),
+  /** 指定したメッセージIDより前のメッセージを取得 */
+  before: z.string().optional(),
+  /** 指定したメッセージIDより後のメッセージを取得 */
+  after: z.string().optional(),
+  /** 指定したメッセージIDの周辺のメッセージを取得 */
+  around: z.string().optional()
+}).strict().refine(
+  (data) => {
+    // before, after, aroundのうち複数が指定されている場合はエラー
+    const paginationParams = [data.before, data.after, data.around].filter(Boolean);
+    return paginationParams.length <= 1;
+  },
+  {
+    message: 'before, after, around のうち複数のパラメータを同時に指定することはできません'
+  }
+);
+
+export type GetChannelMessagesInput = z.infer<typeof GetChannelMessagesInputSchema>;
+
+/**
+ * チャンネルメッセージ取得ツールの出力スキーマ
+ */
+export const GetChannelMessagesOutputSchema = z.object({
+  /** メッセージ一覧 */
+  messages: z.array(z.object({
+    /** メッセージID */
+    id: z.string(),
+    /** チャンネルID */
+    channelId: z.string(),
+    /** サーバーID */
+    guildId: z.string().optional(),
+    /** 送信者情報 */
+    author: z.object({
+      /** ユーザーID */
+      id: z.string(),
+      /** ユーザー名 */
+      username: z.string(),
+      /** ディスクリミネーター */
+      discriminator: z.string(),
+      /** グローバル名 */
+      globalName: z.string().nullable().optional(),
+      /** アバターURL */
+      avatarUrl: z.string().nullable(),
+      /** ボットかどうか */
+      isBot: z.boolean()
+    }),
+    /** メンバー情報（サーバー内の場合） */
+    member: z.object({
+      /** ニックネーム */
+      nickname: z.string().nullable().optional(),
+      /** ロールID一覧 */
+      roles: z.array(z.string())
+    }).optional(),
+    /** メッセージ内容 */
+    content: z.string(),
+    /** 送信日時 */
+    timestamp: z.string(),
+    /** 編集日時 */
+    editedTimestamp: z.string().nullable().optional(),
+    /** TTS（読み上げ）かどうか */
+    tts: z.boolean(),
+    /** @everyone または @here が含まれるか */
+    mentionEveryone: z.boolean(),
+    /** メンション対象ユーザー一覧 */
+    mentions: z.array(z.object({
+      id: z.string(),
+      username: z.string(),
+      discriminator: z.string(),
+      globalName: z.string().nullable().optional()
+    })),
+    /** メンション対象ロール一覧 */
+    mentionRoles: z.array(z.string()),
+    /** 添付ファイル一覧 */
+    attachments: z.array(z.object({
+      id: z.string(),
+      filename: z.string(),
+      size: z.number(),
+      url: z.string(),
+      contentType: z.string().optional(),
+      height: z.number().nullable().optional(),
+      width: z.number().nullable().optional()
+    })),
+    /** 埋め込みコンテンツ数 */
+    embedCount: z.number(),
+    /** リアクション一覧 */
+    reactions: z.array(z.object({
+      emoji: z.object({
+        id: z.string().nullable().optional(),
+        name: z.string().nullable().optional(),
+        animated: z.boolean().optional()
+      }),
+      count: z.number(),
+      me: z.boolean()
+    })).optional(),
+    /** メッセージタイプ */
+    type: z.number(),
+    /** ピン留めされているか */
+    pinned: z.boolean(),
+    /** Webhook送信かどうか */
+    isWebhook: z.boolean()
+  })),
+  /** 総メッセージ数（取得できた分） */
+  totalCount: z.number(),
+  /** 取得したメッセージの最古のID */
+  oldestMessageId: z.string().nullable(),
+  /** 取得したメッセージの最新のID */
+  newestMessageId: z.string().nullable()
+});
+
+export type GetChannelMessagesOutput = z.infer<typeof GetChannelMessagesOutputSchema>;
+
+/**
+ * 特定のDiscordチャンネルのメッセージ一覧を取得
+ */
+export async function getChannelMessages(
+  discordClient: DiscordClient,
+  input: GetChannelMessagesInput
+): Promise<GetChannelMessagesOutput> {
+  try {
+    const options: any = {};
+    
+    if (input.limit !== undefined) {
+      options.limit = input.limit;
+    } else {
+      options.limit = 50; // デフォルト値
+    }
+    
+    if (input.before) options.before = input.before;
+    if (input.after) options.after = input.after;
+    if (input.around) options.around = input.around;
+
+    const messages = await discordClient.getChannelMessages(input.channelId, options);
+
+    const processedMessages = messages.map(message => {
+      const author = {
+        id: message.author.id,
+        username: message.author.username,
+        discriminator: message.author.discriminator,
+        globalName: message.author.global_name || null,
+        avatarUrl: message.author.avatar
+          ? `https://cdn.discordapp.com/avatars/${message.author.id}/${message.author.avatar}.png`
+          : null,
+        isBot: message.author.bot || false
+      };
+
+      const member = message.member ? {
+        nickname: message.member.nick || null,
+        roles: message.member.roles
+      } : undefined;
+
+      const mentions = message.mentions.map(user => ({
+        id: user.id,
+        username: user.username,
+        discriminator: user.discriminator,
+        globalName: user.global_name || null
+      }));
+
+      const attachments = message.attachments.map(attachment => ({
+        id: attachment.id,
+        filename: attachment.filename,
+        size: attachment.size,
+        url: attachment.url,
+        height: attachment.height,
+        width: attachment.width
+      }));
+
+      const reactions = message.reactions?.map(reaction => ({
+        emoji: {
+          id: reaction.emoji.id,
+          name: reaction.emoji.name,
+          animated: reaction.emoji.animated
+        },
+        count: reaction.count,
+        me: reaction.me
+      })) || [];
+
+      return {
+        id: message.id,
+        channelId: message.channel_id,
+        guildId: message.guild_id,
+        author,
+        member,
+        content: message.content,
+        timestamp: message.timestamp,
+        editedTimestamp: message.edited_timestamp,
+        tts: message.tts,
+        mentionEveryone: message.mention_everyone,
+        mentions,
+        mentionRoles: message.mention_roles,
+        attachments,
+        embedCount: message.embeds.length,
+        reactions,
+        type: message.type,
+        pinned: message.pinned,
+        isWebhook: !!message.webhook_id
+      };
+    });
+
+    // メッセージは新しい順で返されるため、最古・最新のIDを取得
+    const oldestMessageId = processedMessages.length > 0 
+      ? processedMessages[processedMessages.length - 1].id 
+      : null;
+    const newestMessageId = processedMessages.length > 0 
+      ? processedMessages[0].id 
+      : null;
+
+    return {
+      messages: processedMessages,
+      totalCount: processedMessages.length,
+      oldestMessageId,
+      newestMessageId
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'チャンネルメッセージの取得中に不明なエラーが発生しました';
+    throw new Error(`チャンネルメッセージの取得に失敗しました: ${errorMessage}`);
+  }
+}

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -155,3 +155,122 @@ export interface DiscordUser {
   /** 公開フラグ */
   public_flags?: number;
 }
+
+export interface DiscordMessage {
+  /** メッセージID */
+  id: string;
+  /** チャンネルID */
+  channel_id: string;
+  /** サーバーID */
+  guild_id?: string;
+  /** 送信者情報 */
+  author: DiscordUser;
+  /** メンバー情報 */
+  member?: DiscordGuildMember;
+  /** メッセージ内容 */
+  content: string;
+  /** 送信日時 */
+  timestamp: string;
+  /** 編集日時 */
+  edited_timestamp?: string | null;
+  /** TTS（読み上げ）かどうか */
+  tts: boolean;
+  /** @everyone または @here が含まれるか */
+  mention_everyone: boolean;
+  /** メンション対象ユーザー一覧 */
+  mentions: DiscordUser[];
+  /** メンション対象ロール一覧 */
+  mention_roles: string[];
+  /** 添付ファイル一覧 */
+  attachments: DiscordAttachment[];
+  /** 埋め込みコンテンツ一覧 */
+  embeds: DiscordEmbed[];
+  /** リアクション一覧 */
+  reactions?: DiscordReaction[];
+  /** メッセージタイプ */
+  type: number;
+  /** メッセージフラグ */
+  flags?: number;
+  /** ピン留めされているか */
+  pinned: boolean;
+  /** Webhook ID */
+  webhook_id?: string;
+}
+
+export interface DiscordAttachment {
+  /** 添付ファイルID */
+  id: string;
+  /** ファイル名 */
+  filename: string;
+  /** ファイルサイズ（バイト） */
+  size: number;
+  /** ファイルURL */
+  url: string;
+  /** プロキシURL */
+  proxy_url: string;
+  /** 画像の高さ */
+  height?: number | null;
+  /** 画像の幅 */
+  width?: number | null;
+}
+
+export interface DiscordEmbed {
+  /** タイトル */
+  title?: string;
+  /** タイプ */
+  type?: string;
+  /** 説明 */
+  description?: string;
+  /** URL */
+  url?: string;
+  /** タイムスタンプ */
+  timestamp?: string;
+  /** カラー */
+  color?: number;
+  /** フッター */
+  footer?: {
+    text: string;
+    icon_url?: string;
+    proxy_icon_url?: string;
+  };
+  /** 画像 */
+  image?: {
+    url?: string;
+    proxy_url?: string;
+    height?: number;
+    width?: number;
+  };
+  /** サムネイル */
+  thumbnail?: {
+    url?: string;
+    proxy_url?: string;
+    height?: number;
+    width?: number;
+  };
+  /** 作成者 */
+  author?: {
+    name?: string;
+    url?: string;
+    icon_url?: string;
+    proxy_icon_url?: string;
+  };
+  /** フィールド一覧 */
+  fields?: {
+    name: string;
+    value: string;
+    inline?: boolean;
+  }[];
+}
+
+export interface DiscordReaction {
+  /** リアクション数 */
+  count: number;
+  /** 自分がリアクションしたか */
+  me: boolean;
+  /** 絵文字情報 */
+  emoji: {
+    id?: string | null;
+    name?: string | null;
+    animated?: boolean;
+  };
+}


### PR DESCRIPTION
## Summary
- get_channel_messages ツールの実装
- ページネーション機能（before, after, around）対応 
- メッセージの詳細情報（添付ファイル、埋め込み、リアクション）を含む取得機能

## Test plan
- [x] ユニットテストの実装と実行
- [x] TypeScript型チェック
- [x] ESLint検証
- [x] ビルド確認

🤖 Generated with [Claude Code](https://claude.ai/code)