### PR TITLE
feat: Discord 特定メッセージ取得機能を追加

### DIFF
--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -145,6 +145,19 @@ export class DiscordClient {
   }
 
   /**
+   * 特定のメッセージの詳細を取得
+   */
+  async getMessage(channelId: string, messageId: string): Promise<DiscordMessage> {
+    try {
+      const response = await this.http.get(`/channels/${channelId}/messages/${messageId}`);
+      return response.data;
+    } catch (error) {
+      this.handleApiError(error as AxiosError);
+      throw error;
+    }
+  }
+
+  /**
    * API エラーハンドリング
    */
   private handleApiError(error: AxiosError): never {

--- a/src/tools/get-message.test.ts
+++ b/src/tools/get-message.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordClient } from '../discord/client.js';
+import { getMessage, GetMessageInputSchema } from './get-message.js';
+import { DiscordMessage } from '../types/discord.js';
+
+// DiscordClientのモック
+vi.mock('../discord/client.js');
+
+describe('getMessage', () => {
+  let mockDiscordClient: vi.Mocked<DiscordClient>;
+
+  beforeEach(() => {
+    mockDiscordClient = {
+      getMessage: vi.fn(),
+    } as any;
+  });
+
+  const mockMessage: DiscordMessage = {
+    id: '123456789',
+    channel_id: '987654321',
+    guild_id: '555666777',
+    author: {
+      id: '111222333',
+      username: 'testuser',
+      discriminator: '1234',
+      avatar: 'avatar_hash',
+      bot: false
+    },
+    content: 'Hello, world!',
+    timestamp: '2023-01-01T00:00:00.000Z',
+    edited_timestamp: null,
+    tts: false,
+    mention_everyone: false,
+    mentions: [],
+    mention_roles: [],
+    attachments: [],
+    embeds: [],
+    reactions: [],
+    type: 0,
+    flags: 0,
+    pinned: false
+  };
+
+  describe('正常系', () => {
+    it('特定のメッセージを取得できる', async () => {
+      mockDiscordClient.getMessage.mockResolvedValue(mockMessage);
+
+      const input = {
+        channelId: '987654321',
+        messageId: '123456789'
+      };
+
+      const result = await getMessage(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getMessage).toHaveBeenCalledWith('987654321', '123456789');
+      expect(result.message.id).toBe('123456789');
+      expect(result.message.content).toBe('Hello, world!');
+      expect(result.message.channelId).toBe('987654321');
+    });
+
+    it('編集されたメッセージを取得できる', async () => {
+      const editedMessage: DiscordMessage = {
+        ...mockMessage,
+        content: 'Edited message',
+        edited_timestamp: '2023-01-01T01:00:00.000Z'
+      };
+      
+      mockDiscordClient.getMessage.mockResolvedValue(editedMessage);
+
+      const input = {
+        channelId: '987654321',
+        messageId: '123456789'
+      };
+
+      const result = await getMessage(mockDiscordClient, input);
+
+      expect(result.message.content).toBe('Edited message');
+      expect(result.message.editedTimestamp).toBe('2023-01-01T01:00:00.000Z');
+    });
+
+    it('添付ファイル付きメッセージを取得できる', async () => {
+      const messageWithAttachment: DiscordMessage = {
+        ...mockMessage,
+        attachments: [{
+          id: 'attachment_123',
+          filename: 'image.png',
+          size: 1024,
+          url: 'https://cdn.discordapp.com/attachments/123/456/image.png',
+          proxy_url: 'https://media.discordapp.net/attachments/123/456/image.png',
+          height: 200,
+          width: 300
+        }]
+      };
+      
+      mockDiscordClient.getMessage.mockResolvedValue(messageWithAttachment);
+
+      const input = {
+        channelId: '987654321',
+        messageId: '123456789'
+      };
+
+      const result = await getMessage(mockDiscordClient, input);
+
+      expect(result.message.attachments).toHaveLength(1);
+      expect(result.message.attachments[0].filename).toBe('image.png');
+      expect(result.message.attachments[0].size).toBe(1024);
+    });
+
+    it('リアクション付きメッセージを取得できる', async () => {
+      const messageWithReactions: DiscordMessage = {
+        ...mockMessage,
+        reactions: [{
+          count: 5,
+          me: true,
+          emoji: {
+            id: null,
+            name: '👍',
+            animated: false
+          }
+        }]
+      };
+      
+      mockDiscordClient.getMessage.mockResolvedValue(messageWithReactions);
+
+      const input = {
+        channelId: '987654321',
+        messageId: '123456789'
+      };
+
+      const result = await getMessage(mockDiscordClient, input);
+
+      expect(result.message.reactions).toHaveLength(1);
+      expect(result.message.reactions[0].count).toBe(5);
+      expect(result.message.reactions[0].me).toBe(true);
+      expect(result.message.reactions[0].emoji.name).toBe('👍');
+    });
+
+    it('埋め込み付きメッセージを取得できる', async () => {
+      const messageWithEmbeds: DiscordMessage = {
+        ...mockMessage,
+        embeds: [{
+          title: 'Test Embed',
+          description: 'This is a test embed',
+          color: 0x00ff00,
+          fields: [{
+            name: 'Field 1',
+            value: 'Value 1',
+            inline: true
+          }]
+        }]
+      };
+      
+      mockDiscordClient.getMessage.mockResolvedValue(messageWithEmbeds);
+
+      const input = {
+        channelId: '987654321',
+        messageId: '123456789'
+      };
+
+      const result = await getMessage(mockDiscordClient, input);
+
+      expect(result.message.embedCount).toBe(1);
+    });
+  });
+
+  describe('異常系', () => {
+    it('Discord APIエラーが発生した場合、適切なエラーメッセージを返す', async () => {
+      const apiError = new Error('Discord API Error: 404 Not Found');
+      mockDiscordClient.getMessage.mockRejectedValue(apiError);
+
+      const input = {
+        channelId: '987654321',
+        messageId: '123456789'
+      };
+
+      await expect(getMessage(mockDiscordClient, input)).rejects.toThrow(
+        'メッセージの取得に失敗しました: Discord API Error: 404 Not Found'
+      );
+    });
+
+    it('不明なエラーが発生した場合、汎用エラーメッセージを返す', async () => {
+      mockDiscordClient.getMessage.mockRejectedValue(null);
+
+      const input = {
+        channelId: '987654321',
+        messageId: '123456789'
+      };
+
+      await expect(getMessage(mockDiscordClient, input)).rejects.toThrow(
+        'メッセージの取得に失敗しました: メッセージの取得中に不明なエラーが発生しました'
+      );
+    });
+  });
+
+  describe('入力バリデーション', () => {
+    it('有効な入力値を正常に検証する', () => {
+      const validInput = {
+        channelId: '123456789',
+        messageId: '987654321'
+      };
+
+      const result = GetMessageInputSchema.safeParse(validInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.channelId).toBe('123456789');
+        expect(result.data.messageId).toBe('987654321');
+      }
+    });
+
+    it('channelIdが空文字の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        channelId: '',
+        messageId: '987654321'
+      };
+
+      const result = GetMessageInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('messageIdが空文字の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        channelId: '123456789',
+        messageId: ''
+      };
+
+      const result = GetMessageInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('必須パラメータが不足している場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        channelId: '123456789'
+        // messageId が不足
+      };
+
+      const result = GetMessageInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/tools/get-message.ts
+++ b/src/tools/get-message.ts
@@ -1,0 +1,182 @@
+import { z } from 'zod';
+import { DiscordClient } from '../discord/client.js';
+
+/**
+ * メッセージ取得ツールの入力スキーマ
+ */
+export const GetMessageInputSchema = z.object({
+  /** チャンネルID（必須） */
+  channelId: z.string().min(1, 'チャンネルIDは必須です'),
+  /** メッセージID（必須） */
+  messageId: z.string().min(1, 'メッセージIDは必須です')
+}).strict();
+
+export type GetMessageInput = z.infer<typeof GetMessageInputSchema>;
+
+/**
+ * メッセージ取得ツールの出力スキーマ
+ */
+export const GetMessageOutputSchema = z.object({
+  /** メッセージ情報 */
+  message: z.object({
+    /** メッセージID */
+    id: z.string(),
+    /** チャンネルID */
+    channelId: z.string(),
+    /** サーバーID */
+    guildId: z.string().optional(),
+    /** 送信者情報 */
+    author: z.object({
+      /** ユーザーID */
+      id: z.string(),
+      /** ユーザー名 */
+      username: z.string(),
+      /** ディスクリミネーター */
+      discriminator: z.string(),
+      /** グローバル名 */
+      globalName: z.string().nullable().optional(),
+      /** アバターURL */
+      avatarUrl: z.string().nullable(),
+      /** ボットかどうか */
+      isBot: z.boolean()
+    }),
+    /** メンバー情報（サーバー内の場合） */
+    member: z.object({
+      /** ニックネーム */
+      nickname: z.string().nullable().optional(),
+      /** ロールID一覧 */
+      roles: z.array(z.string())
+    }).optional(),
+    /** メッセージ内容 */
+    content: z.string(),
+    /** 送信日時 */
+    timestamp: z.string(),
+    /** 編集日時 */
+    editedTimestamp: z.string().nullable().optional(),
+    /** TTS（読み上げ）かどうか */
+    tts: z.boolean(),
+    /** @everyone または @here が含まれるか */
+    mentionEveryone: z.boolean(),
+    /** メンション対象ユーザー一覧 */
+    mentions: z.array(z.object({
+      id: z.string(),
+      username: z.string(),
+      discriminator: z.string(),
+      globalName: z.string().nullable().optional()
+    })),
+    /** メンション対象ロール一覧 */
+    mentionRoles: z.array(z.string()),
+    /** 添付ファイル一覧 */
+    attachments: z.array(z.object({
+      id: z.string(),
+      filename: z.string(),
+      size: z.number(),
+      url: z.string(),
+      contentType: z.string().optional(),
+      height: z.number().nullable().optional(),
+      width: z.number().nullable().optional()
+    })),
+    /** 埋め込みコンテンツ数 */
+    embedCount: z.number(),
+    /** リアクション一覧 */
+    reactions: z.array(z.object({
+      emoji: z.object({
+        id: z.string().nullable().optional(),
+        name: z.string().nullable().optional(),
+        animated: z.boolean().optional()
+      }),
+      count: z.number(),
+      me: z.boolean()
+    })).optional(),
+    /** メッセージタイプ */
+    type: z.number(),
+    /** ピン留めされているか */
+    pinned: z.boolean(),
+    /** Webhook送信かどうか */
+    isWebhook: z.boolean()
+  })
+});
+
+export type GetMessageOutput = z.infer<typeof GetMessageOutputSchema>;
+
+/**
+ * 特定のDiscordメッセージの詳細を取得
+ */
+export async function getMessage(
+  discordClient: DiscordClient,
+  input: GetMessageInput
+): Promise<GetMessageOutput> {
+  try {
+    const message = await discordClient.getMessage(input.channelId, input.messageId);
+
+    const author = {
+      id: message.author.id,
+      username: message.author.username,
+      discriminator: message.author.discriminator,
+      globalName: message.author.global_name || null,
+      avatarUrl: message.author.avatar
+        ? `https://cdn.discordapp.com/avatars/${message.author.id}/${message.author.avatar}.png`
+        : null,
+      isBot: message.author.bot || false
+    };
+
+    const member = message.member ? {
+      nickname: message.member.nick || null,
+      roles: message.member.roles
+    } : undefined;
+
+    const mentions = message.mentions.map(user => ({
+      id: user.id,
+      username: user.username,
+      discriminator: user.discriminator,
+      globalName: user.global_name || null
+    }));
+
+    const attachments = message.attachments.map(attachment => ({
+      id: attachment.id,
+      filename: attachment.filename,
+      size: attachment.size,
+      url: attachment.url,
+      height: attachment.height,
+      width: attachment.width
+    }));
+
+    const reactions = message.reactions?.map(reaction => ({
+      emoji: {
+        id: reaction.emoji.id,
+        name: reaction.emoji.name,
+        animated: reaction.emoji.animated
+      },
+      count: reaction.count,
+      me: reaction.me
+    })) || [];
+
+    const processedMessage = {
+      id: message.id,
+      channelId: message.channel_id,
+      guildId: message.guild_id,
+      author,
+      member,
+      content: message.content,
+      timestamp: message.timestamp,
+      editedTimestamp: message.edited_timestamp,
+      tts: message.tts,
+      mentionEveryone: message.mention_everyone,
+      mentions,
+      mentionRoles: message.mention_roles,
+      attachments,
+      embedCount: message.embeds.length,
+      reactions,
+      type: message.type,
+      pinned: message.pinned,
+      isWebhook: !!message.webhook_id
+    };
+
+    return {
+      message: processedMessage
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'メッセージの取得中に不明なエラーが発生しました';
+    throw new Error(`メッセージの取得に失敗しました: ${errorMessage}`);
+  }
+}


### PR DESCRIPTION
## Summary
- get_message ツールの実装
- 特定メッセージの詳細情報取得機能
- 添付ファイル、埋め込み、リアクション情報を含む完全な取得

## Test plan
- [x] ユニットテストの実装と実行
- [x] TypeScript型チェック
- [x] ESLint検証
- [x] ビルド確認
- [x] タスクリストの更新

🤖 Generated with [Claude Code](https://claude.ai/code)