### PR TITLE
feat: Discord ピン留めメッセージ取得機能を追加

### DIFF
--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -158,6 +158,19 @@ export class DiscordClient {
   }
 
   /**
+   * 特定のチャンネルのピン留めメッセージ一覧を取得
+   */
+  async getPinnedMessages(channelId: string): Promise<DiscordMessage[]> {
+    try {
+      const response = await this.http.get(`/channels/${channelId}/pins`);
+      return response.data;
+    } catch (error) {
+      this.handleApiError(error as AxiosError);
+      throw error;
+    }
+  }
+
+  /**
    * API エラーハンドリング
    */
   private handleApiError(error: AxiosError): never {

--- a/src/tools/get-pinned-messages.test.ts
+++ b/src/tools/get-pinned-messages.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordClient } from '../discord/client.js';
+import { getPinnedMessages, GetPinnedMessagesInputSchema } from './get-pinned-messages.js';
+import { DiscordMessage } from '../types/discord.js';
+
+// DiscordClientのモック
+vi.mock('../discord/client.js');
+
+describe('getPinnedMessages', () => {
+  let mockDiscordClient: vi.Mocked<DiscordClient>;
+
+  beforeEach(() => {
+    mockDiscordClient = {
+      getPinnedMessages: vi.fn(),
+    } as any;
+  });
+
+  const mockPinnedMessage: DiscordMessage = {
+    id: '123456789',
+    channel_id: '987654321',
+    guild_id: '555666777',
+    author: {
+      id: '111222333',
+      username: 'testuser',
+      discriminator: '1234',
+      avatar: 'avatar_hash',
+      bot: false
+    },
+    content: 'This is a pinned message!',
+    timestamp: '2023-01-01T00:00:00.000Z',
+    edited_timestamp: null,
+    tts: false,
+    mention_everyone: false,
+    mentions: [],
+    mention_roles: [],
+    attachments: [],
+    embeds: [],
+    reactions: [],
+    type: 0,
+    flags: 0,
+    pinned: true
+  };
+
+  describe('正常系', () => {
+    it('チャンネルのピン留めメッセージ一覧を取得できる', async () => {
+      mockDiscordClient.getPinnedMessages.mockResolvedValue([mockPinnedMessage]);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      const result = await getPinnedMessages(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getPinnedMessages).toHaveBeenCalledWith('987654321');
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].id).toBe('123456789');
+      expect(result.messages[0].content).toBe('This is a pinned message!');
+      expect(result.messages[0].pinned).toBe(true);
+      expect(result.totalCount).toBe(1);
+    });
+
+    it('複数のピン留めメッセージを取得できる', async () => {
+      const messages: DiscordMessage[] = [
+        mockPinnedMessage,
+        {
+          ...mockPinnedMessage,
+          id: '987654321',
+          content: 'Second pinned message',
+          timestamp: '2023-01-02T00:00:00.000Z'
+        }
+      ];
+      
+      mockDiscordClient.getPinnedMessages.mockResolvedValue(messages);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      const result = await getPinnedMessages(mockDiscordClient, input);
+
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0].id).toBe('123456789');
+      expect(result.messages[1].id).toBe('987654321');
+      expect(result.totalCount).toBe(2);
+    });
+
+    it('空のピン留めメッセージリストを取得できる', async () => {
+      mockDiscordClient.getPinnedMessages.mockResolvedValue([]);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      const result = await getPinnedMessages(mockDiscordClient, input);
+
+      expect(result.messages).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+    });
+
+    it('添付ファイル付きピン留めメッセージを取得できる', async () => {
+      const messageWithAttachment: DiscordMessage = {
+        ...mockPinnedMessage,
+        attachments: [{
+          id: 'attachment_123',
+          filename: 'important.pdf',
+          size: 2048,
+          url: 'https://cdn.discordapp.com/attachments/123/456/important.pdf',
+          proxy_url: 'https://media.discordapp.net/attachments/123/456/important.pdf',
+          height: null,
+          width: null
+        }]
+      };
+      
+      mockDiscordClient.getPinnedMessages.mockResolvedValue([messageWithAttachment]);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      const result = await getPinnedMessages(mockDiscordClient, input);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].attachments).toHaveLength(1);
+      expect(result.messages[0].attachments[0].filename).toBe('important.pdf');
+      expect(result.messages[0].attachments[0].size).toBe(2048);
+    });
+
+    it('埋め込み付きピン留めメッセージを取得できる', async () => {
+      const messageWithEmbeds: DiscordMessage = {
+        ...mockPinnedMessage,
+        embeds: [{
+          title: 'Important Announcement',
+          description: 'This is an important announcement',
+          color: 0xff0000,
+          fields: [{
+            name: 'Details',
+            value: 'Important details here',
+            inline: false
+          }]
+        }]
+      };
+      
+      mockDiscordClient.getPinnedMessages.mockResolvedValue([messageWithEmbeds]);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      const result = await getPinnedMessages(mockDiscordClient, input);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].embedCount).toBe(1);
+    });
+
+    it('リアクション付きピン留めメッセージを取得できる', async () => {
+      const messageWithReactions: DiscordMessage = {
+        ...mockPinnedMessage,
+        reactions: [{
+          count: 10,
+          me: false,
+          emoji: {
+            id: null,
+            name: '📌',
+            animated: false
+          }
+        }]
+      };
+      
+      mockDiscordClient.getPinnedMessages.mockResolvedValue([messageWithReactions]);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      const result = await getPinnedMessages(mockDiscordClient, input);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0].reactions).toHaveLength(1);
+      expect(result.messages[0].reactions[0].count).toBe(10);
+      expect(result.messages[0].reactions[0].emoji.name).toBe('📌');
+    });
+  });
+
+  describe('異常系', () => {
+    it('Discord APIエラーが発生した場合、適切なエラーメッセージを返す', async () => {
+      const apiError = new Error('Discord API Error: 403 Forbidden');
+      mockDiscordClient.getPinnedMessages.mockRejectedValue(apiError);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      await expect(getPinnedMessages(mockDiscordClient, input)).rejects.toThrow(
+        'ピン留めメッセージの取得に失敗しました: Discord API Error: 403 Forbidden'
+      );
+    });
+
+    it('不明なエラーが発生した場合、汎用エラーメッセージを返す', async () => {
+      mockDiscordClient.getPinnedMessages.mockRejectedValue(null);
+
+      const input = {
+        channelId: '987654321'
+      };
+
+      await expect(getPinnedMessages(mockDiscordClient, input)).rejects.toThrow(
+        'ピン留めメッセージの取得に失敗しました: ピン留めメッセージの取得中に不明なエラーが発生しました'
+      );
+    });
+  });
+
+  describe('入力バリデーション', () => {
+    it('有効な入力値を正常に検証する', () => {
+      const validInput = {
+        channelId: '123456789'
+      };
+
+      const result = GetPinnedMessagesInputSchema.safeParse(validInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.channelId).toBe('123456789');
+      }
+    });
+
+    it('channelIdが空文字の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        channelId: ''
+      };
+
+      const result = GetPinnedMessagesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('必須パラメータが不足している場合、バリデーションエラーになる', () => {
+      const invalidInput = {};
+
+      const result = GetPinnedMessagesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/tools/get-pinned-messages.ts
+++ b/src/tools/get-pinned-messages.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+import { DiscordClient } from '../discord/client.js';
+
+/**
+ * ピン留めメッセージ取得ツールの入力スキーマ
+ */
+export const GetPinnedMessagesInputSchema = z.object({
+  /** チャンネルID（必須） */
+  channelId: z.string().min(1, 'チャンネルIDは必須です')
+}).strict();
+
+export type GetPinnedMessagesInput = z.infer<typeof GetPinnedMessagesInputSchema>;
+
+/**
+ * ピン留めメッセージ取得ツールの出力スキーマ
+ */
+export const GetPinnedMessagesOutputSchema = z.object({
+  /** ピン留めメッセージ一覧 */
+  messages: z.array(z.object({
+    /** メッセージID */
+    id: z.string(),
+    /** チャンネルID */
+    channelId: z.string(),
+    /** サーバーID */
+    guildId: z.string().optional(),
+    /** 送信者情報 */
+    author: z.object({
+      /** ユーザーID */
+      id: z.string(),
+      /** ユーザー名 */
+      username: z.string(),
+      /** ディスクリミネーター */
+      discriminator: z.string(),
+      /** グローバル名 */
+      globalName: z.string().nullable().optional(),
+      /** アバターURL */
+      avatarUrl: z.string().nullable(),
+      /** ボットかどうか */
+      isBot: z.boolean()
+    }),
+    /** メンバー情報（サーバー内の場合） */
+    member: z.object({
+      /** ニックネーム */
+      nickname: z.string().nullable().optional(),
+      /** ロールID一覧 */
+      roles: z.array(z.string())
+    }).optional(),
+    /** メッセージ内容 */
+    content: z.string(),
+    /** 送信日時 */
+    timestamp: z.string(),
+    /** 編集日時 */
+    editedTimestamp: z.string().nullable().optional(),
+    /** TTS（読み上げ）かどうか */
+    tts: z.boolean(),
+    /** @everyone または @here が含まれるか */
+    mentionEveryone: z.boolean(),
+    /** メンション対象ユーザー一覧 */
+    mentions: z.array(z.object({
+      id: z.string(),
+      username: z.string(),
+      discriminator: z.string(),
+      globalName: z.string().nullable().optional()
+    })),
+    /** メンション対象ロール一覧 */
+    mentionRoles: z.array(z.string()),
+    /** 添付ファイル一覧 */
+    attachments: z.array(z.object({
+      id: z.string(),
+      filename: z.string(),
+      size: z.number(),
+      url: z.string(),
+      contentType: z.string().optional(),
+      height: z.number().nullable().optional(),
+      width: z.number().nullable().optional()
+    })),
+    /** 埋め込みコンテンツ数 */
+    embedCount: z.number(),
+    /** リアクション一覧 */
+    reactions: z.array(z.object({
+      emoji: z.object({
+        id: z.string().nullable().optional(),
+        name: z.string().nullable().optional(),
+        animated: z.boolean().optional()
+      }),
+      count: z.number(),
+      me: z.boolean()
+    })).optional(),
+    /** メッセージタイプ */
+    type: z.number(),
+    /** ピン留めされているか（常にtrue） */
+    pinned: z.boolean(),
+    /** Webhook送信かどうか */
+    isWebhook: z.boolean()
+  })),
+  /** 総ピン留めメッセージ数 */
+  totalCount: z.number(),
+  /** 最も古いピン留めメッセージID */
+  oldestMessageId: z.string().nullable(),
+  /** 最も新しいピン留めメッセージID */
+  newestMessageId: z.string().nullable()
+});
+
+export type GetPinnedMessagesOutput = z.infer<typeof GetPinnedMessagesOutputSchema>;
+
+/**
+ * 特定のDiscordチャンネルのピン留めメッセージ一覧を取得
+ */
+export async function getPinnedMessages(
+  discordClient: DiscordClient,
+  input: GetPinnedMessagesInput
+): Promise<GetPinnedMessagesOutput> {
+  try {
+    const messages = await discordClient.getPinnedMessages(input.channelId);
+
+    const processedMessages = messages.map(message => {
+      const author = {
+        id: message.author.id,
+        username: message.author.username,
+        discriminator: message.author.discriminator,
+        globalName: message.author.global_name || null,
+        avatarUrl: message.author.avatar
+          ? `https://cdn.discordapp.com/avatars/${message.author.id}/${message.author.avatar}.png`
+          : null,
+        isBot: message.author.bot || false
+      };
+
+      const member = message.member ? {
+        nickname: message.member.nick || null,
+        roles: message.member.roles
+      } : undefined;
+
+      const mentions = message.mentions.map(user => ({
+        id: user.id,
+        username: user.username,
+        discriminator: user.discriminator,
+        globalName: user.global_name || null
+      }));
+
+      const attachments = message.attachments.map(attachment => ({
+        id: attachment.id,
+        filename: attachment.filename,
+        size: attachment.size,
+        url: attachment.url,
+        height: attachment.height,
+        width: attachment.width
+      }));
+
+      const reactions = message.reactions?.map(reaction => ({
+        emoji: {
+          id: reaction.emoji.id,
+          name: reaction.emoji.name,
+          animated: reaction.emoji.animated
+        },
+        count: reaction.count,
+        me: reaction.me
+      })) || [];
+
+      return {
+        id: message.id,
+        channelId: message.channel_id,
+        guildId: message.guild_id,
+        author,
+        member,
+        content: message.content,
+        timestamp: message.timestamp,
+        editedTimestamp: message.edited_timestamp,
+        tts: message.tts,
+        mentionEveryone: message.mention_everyone,
+        mentions,
+        mentionRoles: message.mention_roles,
+        attachments,
+        embedCount: message.embeds.length,
+        reactions,
+        type: message.type,
+        pinned: message.pinned,
+        isWebhook: !!message.webhook_id
+      };
+    });
+
+    // ピン留めメッセージは新しい順で返されるため、最古・最新のIDを取得
+    const oldestMessageId = processedMessages.length > 0 
+      ? processedMessages[processedMessages.length - 1].id 
+      : null;
+    const newestMessageId = processedMessages.length > 0 
+      ? processedMessages[0].id 
+      : null;
+
+    return {
+      messages: processedMessages,
+      totalCount: processedMessages.length,
+      oldestMessageId,
+      newestMessageId
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'ピン留めメッセージの取得中に不明なエラーが発生しました';
+    throw new Error(`ピン留めメッセージの取得に失敗しました: ${errorMessage}`);
+  }
+}


### PR DESCRIPTION
## Summary
- get_pinned_messages ツールの実装
- チャンネルのピン留めメッセージ一覧取得機能
- 添付ファイル、埋め込み、リアクション情報を含む完全な取得

## Test plan
- [x] ユニットテストの実装と実行
- [x] TypeScript型チェック
- [x] ESLint検証
- [x] ビルド確認
- [x] タスクリストの更新

🤖 Generated with [Claude Code](https://claude.ai/code)