### PR TITLE
feat: Discord サーバーロール取得機能を追加

### DIFF
--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
-import { DiscordGuild, DiscordApiError, DiscordBotUser, DiscordGuildDetailed, DiscordChannel, DiscordGuildMember, DiscordMessage } from '../types/discord.js';
+import { DiscordGuild, DiscordApiError, DiscordBotUser, DiscordGuildDetailed, DiscordChannel, DiscordGuildMember, DiscordMessage, DiscordRole } from '../types/discord.js';
 
 /**
  * Discord REST API クライアント
@@ -150,6 +150,19 @@ export class DiscordClient {
   async getMessage(channelId: string, messageId: string): Promise<DiscordMessage> {
     try {
       const response = await this.http.get(`/channels/${channelId}/messages/${messageId}`);
+      return response.data;
+    } catch (error) {
+      this.handleApiError(error as AxiosError);
+      throw error;
+    }
+  }
+
+  /**
+   * 特定のサーバーのロール一覧を取得
+   */
+  async getGuildRoles(guildId: string): Promise<DiscordRole[]> {
+    try {
+      const response = await this.http.get(`/guilds/${guildId}/roles`);
       return response.data;
     } catch (error) {
       this.handleApiError(error as AxiosError);

--- a/src/tools/get-guild-roles.test.ts
+++ b/src/tools/get-guild-roles.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordClient } from '../discord/client.js';
+import { getGuildRoles, GetGuildRolesInputSchema } from './get-guild-roles.js';
+import { DiscordRole } from '../types/discord.js';
+
+// DiscordClientのモック
+vi.mock('../discord/client.js');
+
+describe('getGuildRoles', () => {
+  let mockDiscordClient: vi.Mocked<DiscordClient>;
+
+  beforeEach(() => {
+    mockDiscordClient = {
+      getGuildRoles: vi.fn(),
+    } as any;
+  });
+
+  const mockRole: DiscordRole = {
+    id: '123456789',
+    name: 'Admin',
+    color: 0xff0000,
+    hoist: true,
+    icon: null,
+    unicode_emoji: null,
+    position: 5,
+    permissions: '8',
+    managed: false,
+    mentionable: true
+  };
+
+  const mockEveryoneRole: DiscordRole = {
+    id: '987654321',
+    name: '@everyone',
+    color: 0,
+    hoist: false,
+    icon: null,
+    unicode_emoji: null,
+    position: 0,
+    permissions: '104324673',
+    managed: false,
+    mentionable: false
+  };
+
+  describe('正常系', () => {
+    it('サーバーのロール一覧を取得できる', async () => {
+      mockDiscordClient.getGuildRoles.mockResolvedValue([mockRole, mockEveryoneRole]);
+
+      const input = {
+        guildId: '555666777'
+      };
+
+      const result = await getGuildRoles(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getGuildRoles).toHaveBeenCalledWith('555666777');
+      expect(result.roles).toHaveLength(2);
+      expect(result.roles[0].id).toBe('123456789');
+      expect(result.roles[0].name).toBe('Admin');
+      expect(result.roles[1].name).toBe('@everyone');
+      expect(result.totalCount).toBe(2);
+    });
+
+    it('管理者権限フィルターを適用してロールを取得できる', async () => {
+      const adminRole: DiscordRole = {
+        ...mockRole,
+        permissions: '8' // ADMINISTRATOR権限
+      };
+      const normalRole: DiscordRole = {
+        ...mockRole,
+        id: '111222333',
+        name: 'Member',
+        permissions: '104324673'
+      };
+
+      mockDiscordClient.getGuildRoles.mockResolvedValue([adminRole, normalRole, mockEveryoneRole]);
+
+      const input = {
+        guildId: '555666777',
+        adminOnly: true
+      };
+
+      const result = await getGuildRoles(mockDiscordClient, input);
+
+      expect(result.roles).toHaveLength(1);
+      expect(result.roles[0].name).toBe('Admin');
+      expect(result.roles[0].isAdmin).toBe(true);
+    });
+
+    it('管理ロールを除外してロールを取得できる', async () => {
+      const managedRole: DiscordRole = {
+        ...mockRole,
+        id: '111222333',
+        name: 'Bot Role',
+        managed: true,
+        tags: {
+          bot_id: '444555666'
+        }
+      };
+
+      mockDiscordClient.getGuildRoles.mockResolvedValue([mockRole, managedRole, mockEveryoneRole]);
+
+      const input = {
+        guildId: '555666777',
+        excludeManaged: true
+      };
+
+      const result = await getGuildRoles(mockDiscordClient, input);
+
+      expect(result.roles).toHaveLength(2);
+      expect(result.roles.find(r => r.name === 'Bot Role')).toBeUndefined();
+    });
+
+    it('詳細情報を含めてロールを取得できる', async () => {
+      const roleWithTags: DiscordRole = {
+        ...mockRole,
+        tags: {
+          premium_subscriber: null
+        }
+      };
+
+      mockDiscordClient.getGuildRoles.mockResolvedValue([roleWithTags]);
+
+      const input = {
+        guildId: '555666777',
+        includeDetails: true
+      };
+
+      const result = await getGuildRoles(mockDiscordClient, input);
+
+      expect(result.roles).toHaveLength(1);
+      expect(result.roles[0].tags).toBeDefined();
+      expect(result.roles[0].tags?.isPremiumSubscriber).toBe(true);
+    });
+
+    it('空のロールリストを取得できる', async () => {
+      mockDiscordClient.getGuildRoles.mockResolvedValue([]);
+
+      const input = {
+        guildId: '555666777'
+      };
+
+      const result = await getGuildRoles(mockDiscordClient, input);
+
+      expect(result.roles).toHaveLength(0);
+      expect(result.totalCount).toBe(0);
+    });
+
+    it('色付きロールを正しく処理できる', async () => {
+      const coloredRole: DiscordRole = {
+        ...mockRole,
+        color: 0x00ff00
+      };
+
+      mockDiscordClient.getGuildRoles.mockResolvedValue([coloredRole]);
+
+      const input = {
+        guildId: '555666777'
+      };
+
+      const result = await getGuildRoles(mockDiscordClient, input);
+
+      expect(result.roles[0].color).toBe('#00ff00');
+      expect(result.roles[0].colorValue).toBe(65280);
+    });
+
+    it('ホイストされたロールを正しく処理できる', async () => {
+      const hoistedRole: DiscordRole = {
+        ...mockRole,
+        hoist: true
+      };
+
+      mockDiscordClient.getGuildRoles.mockResolvedValue([hoistedRole]);
+
+      const input = {
+        guildId: '555666777'
+      };
+
+      const result = await getGuildRoles(mockDiscordClient, input);
+
+      expect(result.roles[0].hoist).toBe(true);
+    });
+  });
+
+  describe('異常系', () => {
+    it('Discord APIエラーが発生した場合、適切なエラーメッセージを返す', async () => {
+      const apiError = new Error('Discord API Error: 403 Forbidden');
+      mockDiscordClient.getGuildRoles.mockRejectedValue(apiError);
+
+      const input = {
+        guildId: '555666777'
+      };
+
+      await expect(getGuildRoles(mockDiscordClient, input)).rejects.toThrow(
+        'サーバーロールの取得に失敗しました: Discord API Error: 403 Forbidden'
+      );
+    });
+
+    it('不明なエラーが発生した場合、汎用エラーメッセージを返す', async () => {
+      mockDiscordClient.getGuildRoles.mockRejectedValue(null);
+
+      const input = {
+        guildId: '555666777'
+      };
+
+      await expect(getGuildRoles(mockDiscordClient, input)).rejects.toThrow(
+        'サーバーロールの取得に失敗しました: サーバーロールの取得中に不明なエラーが発生しました'
+      );
+    });
+  });
+
+  describe('入力バリデーション', () => {
+    it('有効な入力値を正常に検証する', () => {
+      const validInput = {
+        guildId: '123456789',
+        adminOnly: false,
+        excludeManaged: true,
+        includeDetails: false
+      };
+
+      const result = GetGuildRolesInputSchema.safeParse(validInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.guildId).toBe('123456789');
+      }
+    });
+
+    it('guildIdが空文字の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        guildId: ''
+      };
+
+      const result = GetGuildRolesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('必須パラメータが不足している場合、バリデーションエラーになる', () => {
+      const invalidInput = {};
+
+      const result = GetGuildRolesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/tools/get-guild-roles.ts
+++ b/src/tools/get-guild-roles.ts
@@ -1,0 +1,170 @@
+import { z } from 'zod';
+import { DiscordClient } from '../discord/client.js';
+
+/**
+ * サーバーロール取得ツールの入力スキーマ
+ */
+export const GetGuildRolesInputSchema = z.object({
+  /** サーバーID（必須） */
+  guildId: z.string().min(1, 'サーバーIDは必須です'),
+  /** 管理者権限を持つロールのみ取得 */
+  adminOnly: z.boolean().optional().default(false),
+  /** 管理ロール（Bot、統合など）を除外 */
+  excludeManaged: z.boolean().optional().default(false),
+  /** 詳細情報を含めるかどうか */
+  includeDetails: z.boolean().optional().default(false)
+}).strict();
+
+export type GetGuildRolesInput = z.infer<typeof GetGuildRolesInputSchema>;
+
+/**
+ * サーバーロール取得ツールの出力スキーマ
+ */
+export const GetGuildRolesOutputSchema = z.object({
+  /** ロール一覧 */
+  roles: z.array(z.object({
+    /** ロールID */
+    id: z.string(),
+    /** ロール名 */
+    name: z.string(),
+    /** ロールの色（16進数） */
+    color: z.string(),
+    /** ロールの色（数値） */
+    colorValue: z.number(),
+    /** ホイスト（別表示）されるか */
+    hoist: z.boolean(),
+    /** 表示順序の位置 */
+    position: z.number(),
+    /** ロールの権限（ビットフラグ） */
+    permissions: z.string(),
+    /** 管理者権限を持つか */
+    isAdmin: z.boolean(),
+    /** 管理ロールか（Bot、統合など） */
+    managed: z.boolean(),
+    /** メンション可能か */
+    mentionable: z.boolean(),
+    /** メンバー数（詳細情報が有効な場合） */
+    memberCount: z.number().optional(),
+    /** ロールタグ（詳細情報が有効な場合） */
+    tags: z.object({
+      /** ボット専用ロールか */
+      isBot: z.boolean(),
+      /** 統合ロールか */
+      isIntegration: z.boolean(),
+      /** プレミアムサブスクライバー専用か */
+      isPremiumSubscriber: z.boolean(),
+      /** ギルドコネクション専用か */
+      isGuildConnections: z.boolean(),
+      /** 購入可能か */
+      isAvailableForPurchase: z.boolean()
+    }).optional(),
+    /** アイコンURL（詳細情報が有効な場合） */
+    iconUrl: z.string().nullable().optional(),
+    /** Unicode絵文字（詳細情報が有効な場合） */
+    unicodeEmoji: z.string().nullable().optional()
+  })),
+  /** 総ロール数 */
+  totalCount: z.number(),
+  /** フィルター適用後のロール数 */
+  filteredCount: z.number(),
+  /** 管理者ロール数 */
+  adminRoleCount: z.number(),
+  /** 管理ロール数 */
+  managedRoleCount: z.number()
+});
+
+export type GetGuildRolesOutput = z.infer<typeof GetGuildRolesOutputSchema>;
+
+/**
+ * 特定のDiscordサーバーのロール一覧を取得
+ */
+export async function getGuildRoles(
+  discordClient: DiscordClient,
+  input: GetGuildRolesInput
+): Promise<GetGuildRolesOutput> {
+  try {
+    const roles = await discordClient.getGuildRoles(input.guildId);
+
+    // フィルター処理
+    let filteredRoles = roles;
+
+    if (input.adminOnly) {
+      filteredRoles = filteredRoles.filter(role => {
+        const permissions = BigInt(role.permissions);
+        const adminPermission = BigInt('8'); // ADMINISTRATOR permission
+        return (permissions & adminPermission) === adminPermission;
+      });
+    }
+
+    if (input.excludeManaged) {
+      filteredRoles = filteredRoles.filter(role => !role.managed);
+    }
+
+    const processedRoles = filteredRoles.map(role => {
+      // 色を16進数に変換
+      const colorHex = role.color.toString(16).padStart(6, '0');
+      const color = role.color === 0 ? '#000000' : `#${colorHex}`;
+
+      // 管理者権限チェック
+      const permissions = BigInt(role.permissions);
+      const adminPermission = BigInt('8');
+      const isAdmin = (permissions & adminPermission) === adminPermission;
+
+      const roleInfo: any = {
+        id: role.id,
+        name: role.name,
+        color,
+        colorValue: role.color,
+        hoist: role.hoist,
+        position: role.position,
+        permissions: role.permissions,
+        isAdmin,
+        managed: role.managed,
+        mentionable: role.mentionable
+      };
+
+      // 詳細情報が要求された場合
+      if (input.includeDetails) {
+        if (role.tags) {
+          roleInfo.tags = {
+            isBot: !!role.tags.bot_id,
+            isIntegration: !!role.tags.integration_id,
+            isPremiumSubscriber: role.tags.premium_subscriber !== undefined,
+            isGuildConnections: role.tags.guild_connections !== undefined,
+            isAvailableForPurchase: role.tags.available_for_purchase !== undefined
+          };
+        }
+
+        if (role.icon) {
+          roleInfo.iconUrl = `https://cdn.discordapp.com/role-icons/${role.id}/${role.icon}.png`;
+        } else {
+          roleInfo.iconUrl = null;
+        }
+
+        roleInfo.unicodeEmoji = role.unicode_emoji || null;
+      }
+
+      return roleInfo;
+    });
+
+    // 統計情報を計算
+    const adminRoleCount = roles.filter(role => {
+      const permissions = BigInt(role.permissions);
+      const adminPermission = BigInt('8');
+      return (permissions & adminPermission) === adminPermission;
+    }).length;
+
+    const managedRoleCount = roles.filter(role => role.managed).length;
+
+    return {
+      roles: processedRoles,
+      totalCount: roles.length,
+      filteredCount: processedRoles.length,
+      adminRoleCount,
+      managedRoleCount
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'サーバーロールの取得中に不明なエラーが発生しました';
+    throw new Error(`サーバーロールの取得に失敗しました: ${errorMessage}`);
+  }
+}

--- a/src/types/discord.ts
+++ b/src/types/discord.ts
@@ -274,3 +274,39 @@ export interface DiscordReaction {
     animated?: boolean;
   };
 }
+
+export interface DiscordRole {
+  /** ロールID */
+  id: string;
+  /** ロール名 */
+  name: string;
+  /** ロールの色 */
+  color: number;
+  /** ホイスト（別表示）されるか */
+  hoist: boolean;
+  /** アイコンハッシュ */
+  icon?: string | null;
+  /** Unicode絵文字 */
+  unicode_emoji?: string | null;
+  /** 表示順序の位置 */
+  position: number;
+  /** ロールの権限 */
+  permissions: string;
+  /** 管理者権限を持つか */
+  managed: boolean;
+  /** メンション可能か */
+  mentionable: boolean;
+  /** ロールタグ */
+  tags?: {
+    /** ボットID（ボット専用ロールの場合） */
+    bot_id?: string;
+    /** 統合ID（統合ロールの場合） */
+    integration_id?: string;
+    /** プレミアムサブスクライバー専用か */
+    premium_subscriber?: null;
+    /** ギルドコネクション専用か */
+    guild_connections?: null;
+    /** 利用可能な購入フラグ */
+    available_for_purchase?: null;
+  };
+}


### PR DESCRIPTION
## Summary
- get_guild_roles ツールの実装
- サーバーのロール一覧取得機能
- 管理者権限フィルタリング機能
- 管理ロール除外機能
- 詳細情報取得機能（タグ、アイコン、絵文字）

## Test plan
- [x] ユニットテストの実装と実行
- [x] TypeScript型チェック
- [x] ESLint検証
- [x] ビルド確認
- [x] タスクリストの更新

🤖 Generated with [Claude Code](https://claude.ai/code)