### PR TITLE
feat: Discord メンバーロール取得機能を追加

### DIFF
--- a/src/discord/client.ts
+++ b/src/discord/client.ts
@@ -184,6 +184,19 @@ export class DiscordClient {
   }
 
   /**
+   * 特定のサーバーの特定メンバーの詳細を取得
+   */
+  async getGuildMember(guildId: string, userId: string): Promise<DiscordGuildMember> {
+    try {
+      const response = await this.http.get(`/guilds/${guildId}/members/${userId}`);
+      return response.data;
+    } catch (error) {
+      this.handleApiError(error as AxiosError);
+      throw error;
+    }
+  }
+
+  /**
    * API エラーハンドリング
    */
   private handleApiError(error: AxiosError): never {

--- a/src/tools/get-member-roles.test.ts
+++ b/src/tools/get-member-roles.test.ts
@@ -1,0 +1,345 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordClient } from '../discord/client.js';
+import { getMemberRoles, GetMemberRolesInputSchema } from './get-member-roles.js';
+import { DiscordGuildMember, DiscordRole } from '../types/discord.js';
+
+// DiscordClientのモック
+vi.mock('../discord/client.js');
+
+describe('getMemberRoles', () => {
+  let mockDiscordClient: vi.Mocked<DiscordClient>;
+
+  beforeEach(() => {
+    mockDiscordClient = {
+      getGuildMember: vi.fn(),
+      getGuildRoles: vi.fn(),
+    } as any;
+  });
+
+  const mockMember: DiscordGuildMember = {
+    user: {
+      id: '111222333',
+      username: 'testuser',
+      discriminator: '1234',
+      avatar: 'avatar_hash',
+      bot: false
+    },
+    nick: 'Test User',
+    avatar: null,
+    roles: ['123456789', '987654321'],
+    joined_at: '2023-01-01T00:00:00.000Z',
+    premium_since: null,
+    deaf: false,
+    mute: false,
+    flags: 0
+  };
+
+  const mockRoles: DiscordRole[] = [
+    {
+      id: '123456789',
+      name: 'Admin',
+      color: 0xff0000,
+      hoist: true,
+      icon: null,
+      unicode_emoji: null,
+      position: 5,
+      permissions: '8',
+      managed: false,
+      mentionable: true
+    },
+    {
+      id: '987654321',
+      name: 'Member',
+      color: 0x00ff00,
+      hoist: false,
+      icon: null,
+      unicode_emoji: null,
+      position: 1,
+      permissions: '104324673',
+      managed: false,
+      mentionable: true
+    },
+    {
+      id: '555666777',
+      name: '@everyone',
+      color: 0,
+      hoist: false,
+      icon: null,
+      unicode_emoji: null,
+      position: 0,
+      permissions: '104324673',
+      managed: false,
+      mentionable: false
+    }
+  ];
+
+  describe('正常系', () => {
+    it('メンバーのロール一覧を取得できる', async () => {
+      mockDiscordClient.getGuildMember.mockResolvedValue(mockMember);
+      mockDiscordClient.getGuildRoles.mockResolvedValue(mockRoles);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333'
+      };
+
+      const result = await getMemberRoles(mockDiscordClient, input);
+
+      expect(mockDiscordClient.getGuildMember).toHaveBeenCalledWith('555666777', '111222333');
+      expect(mockDiscordClient.getGuildRoles).toHaveBeenCalledWith('555666777');
+      expect(result.member.id).toBe('111222333');
+      expect(result.member.username).toBe('testuser');
+      expect(result.roles).toHaveLength(2);
+      expect(result.roles[0].name).toBe('Admin');
+      expect(result.roles[1].name).toBe('Member');
+    });
+
+    it('管理者権限を持つロールのみフィルタリングできる', async () => {
+      mockDiscordClient.getGuildMember.mockResolvedValue(mockMember);
+      mockDiscordClient.getGuildRoles.mockResolvedValue(mockRoles);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333',
+        adminOnly: true
+      };
+
+      const result = await getMemberRoles(mockDiscordClient, input);
+
+      expect(result.roles).toHaveLength(1);
+      expect(result.roles[0].name).toBe('Admin');
+      expect(result.roles[0].isAdmin).toBe(true);
+    });
+
+    it('管理ロールを除外してフィルタリングできる', async () => {
+      const managedRole: DiscordRole = {
+        ...mockRoles[0],
+        id: '444555666',
+        name: 'Bot Role',
+        managed: true,
+        tags: {
+          bot_id: '999888777'
+        }
+      };
+
+      const memberWithManagedRole: DiscordGuildMember = {
+        ...mockMember,
+        roles: ['123456789', '444555666', '987654321']
+      };
+
+      mockDiscordClient.getGuildMember.mockResolvedValue(memberWithManagedRole);
+      mockDiscordClient.getGuildRoles.mockResolvedValue([...mockRoles, managedRole]);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333',
+        excludeManaged: true
+      };
+
+      const result = await getMemberRoles(mockDiscordClient, input);
+
+      expect(result.roles).toHaveLength(2);
+      expect(result.roles.find(r => r.name === 'Bot Role')).toBeUndefined();
+    });
+
+    it('詳細情報を含めてロールを取得できる', async () => {
+      const roleWithDetails: DiscordRole = {
+        ...mockRoles[0],
+        icon: 'icon_hash',
+        unicode_emoji: '👑',
+        tags: {
+          premium_subscriber: null
+        }
+      };
+
+      mockDiscordClient.getGuildMember.mockResolvedValue(mockMember);
+      mockDiscordClient.getGuildRoles.mockResolvedValue([roleWithDetails, ...mockRoles.slice(1)]);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333',
+        includeDetails: true
+      };
+
+      const result = await getMemberRoles(mockDiscordClient, input);
+
+      expect(result.roles[0].iconUrl).toBeDefined();
+      expect(result.roles[0].unicodeEmoji).toBe('👑');
+      expect(result.roles[0].tags).toBeDefined();
+    });
+
+    it('ニックネーム付きメンバーの情報を正しく処理できる', async () => {
+      mockDiscordClient.getGuildMember.mockResolvedValue(mockMember);
+      mockDiscordClient.getGuildRoles.mockResolvedValue(mockRoles);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333'
+      };
+
+      const result = await getMemberRoles(mockDiscordClient, input);
+
+      expect(result.member.nickname).toBe('Test User');
+    });
+
+    it('ニックネームなしメンバーの情報を正しく処理できる', async () => {
+      const memberWithoutNick: DiscordGuildMember = {
+        ...mockMember,
+        nick: null
+      };
+
+      mockDiscordClient.getGuildMember.mockResolvedValue(memberWithoutNick);
+      mockDiscordClient.getGuildRoles.mockResolvedValue(mockRoles);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333'
+      };
+
+      const result = await getMemberRoles(mockDiscordClient, input);
+
+      expect(result.member.nickname).toBeNull();
+    });
+
+    it('ロールを持たないメンバーの場合空配列を返す', async () => {
+      const memberWithoutRoles: DiscordGuildMember = {
+        ...mockMember,
+        roles: []
+      };
+
+      mockDiscordClient.getGuildMember.mockResolvedValue(memberWithoutRoles);
+      mockDiscordClient.getGuildRoles.mockResolvedValue(mockRoles);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333'
+      };
+
+      const result = await getMemberRoles(mockDiscordClient, input);
+
+      expect(result.roles).toHaveLength(0);
+      expect(result.totalRoleCount).toBe(0);
+    });
+
+    it('プレミアムメンバーの情報を正しく処理できる', async () => {
+      const premiumMember: DiscordGuildMember = {
+        ...mockMember,
+        premium_since: '2023-06-01T00:00:00.000Z'
+      };
+
+      mockDiscordClient.getGuildMember.mockResolvedValue(premiumMember);
+      mockDiscordClient.getGuildRoles.mockResolvedValue(mockRoles);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333'
+      };
+
+      const result = await getMemberRoles(mockDiscordClient, input);
+
+      expect(result.member.premiumSince).toBe('2023-06-01T00:00:00.000Z');
+    });
+  });
+
+  describe('異常系', () => {
+    it('メンバーが見つからない場合、適切なエラーメッセージを返す', async () => {
+      const notFoundError = new Error('Discord API Error: 404 Not Found');
+      mockDiscordClient.getGuildMember.mockRejectedValue(notFoundError);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333'
+      };
+
+      await expect(getMemberRoles(mockDiscordClient, input)).rejects.toThrow(
+        'メンバーロールの取得に失敗しました: Discord API Error: 404 Not Found'
+      );
+    });
+
+    it('サーバーロール取得でエラーが発生した場合、適切なエラーメッセージを返す', async () => {
+      mockDiscordClient.getGuildMember.mockResolvedValue(mockMember);
+      const rolesError = new Error('Discord API Error: 403 Forbidden');
+      mockDiscordClient.getGuildRoles.mockRejectedValue(rolesError);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333'
+      };
+
+      await expect(getMemberRoles(mockDiscordClient, input)).rejects.toThrow(
+        'メンバーロールの取得に失敗しました: Discord API Error: 403 Forbidden'
+      );
+    });
+
+    it('不明なエラーが発生した場合、汎用エラーメッセージを返す', async () => {
+      mockDiscordClient.getGuildMember.mockRejectedValue(null);
+
+      const input = {
+        guildId: '555666777',
+        userId: '111222333'
+      };
+
+      await expect(getMemberRoles(mockDiscordClient, input)).rejects.toThrow(
+        'メンバーロールの取得に失敗しました: メンバーロールの取得中に不明なエラーが発生しました'
+      );
+    });
+  });
+
+  describe('入力バリデーション', () => {
+    it('有効な入力値を正常に検証する', () => {
+      const validInput = {
+        guildId: '555666777',
+        userId: '111222333',
+        adminOnly: false,
+        excludeManaged: true,
+        includeDetails: false
+      };
+
+      const result = GetMemberRolesInputSchema.safeParse(validInput);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.guildId).toBe('555666777');
+        expect(result.data.userId).toBe('111222333');
+      }
+    });
+
+    it('guildIdが空文字の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        guildId: '',
+        userId: '111222333'
+      };
+
+      const result = GetMemberRolesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('userIdが空文字の場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        guildId: '555666777',
+        userId: ''
+      };
+
+      const result = GetMemberRolesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('必須パラメータが不足している場合、バリデーションエラーになる', () => {
+      const invalidInput = {
+        guildId: '555666777'
+        // userId が不足
+      };
+
+      const result = GetMemberRolesInputSchema.safeParse(invalidInput);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.errors.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/src/tools/get-member-roles.ts
+++ b/src/tools/get-member-roles.ts
@@ -1,0 +1,220 @@
+import { z } from 'zod';
+import { DiscordClient } from '../discord/client.js';
+
+/**
+ * メンバーロール取得ツールの入力スキーマ
+ */
+export const GetMemberRolesInputSchema = z.object({
+  /** サーバーID（必須） */
+  guildId: z.string().min(1, 'サーバーIDは必須です'),
+  /** ユーザーID（必須） */
+  userId: z.string().min(1, 'ユーザーIDは必須です'),
+  /** 管理者権限を持つロールのみ取得 */
+  adminOnly: z.boolean().optional().default(false),
+  /** 管理ロール（Bot、統合など）を除外 */
+  excludeManaged: z.boolean().optional().default(false),
+  /** 詳細情報を含めるかどうか */
+  includeDetails: z.boolean().optional().default(false)
+}).strict();
+
+export type GetMemberRolesInput = z.infer<typeof GetMemberRolesInputSchema>;
+
+/**
+ * メンバーロール取得ツールの出力スキーマ
+ */
+export const GetMemberRolesOutputSchema = z.object({
+  /** メンバー情報 */
+  member: z.object({
+    /** ユーザーID */
+    id: z.string(),
+    /** ユーザー名 */
+    username: z.string(),
+    /** ディスクリミネーター */
+    discriminator: z.string(),
+    /** グローバル名 */
+    globalName: z.string().nullable().optional(),
+    /** ニックネーム */
+    nickname: z.string().nullable(),
+    /** アバターURL */
+    avatarUrl: z.string().nullable(),
+    /** ボットかどうか */
+    isBot: z.boolean(),
+    /** サーバー参加日時 */
+    joinedAt: z.string(),
+    /** ブースト開始日時 */
+    premiumSince: z.string().nullable().optional()
+  }),
+  /** ロール一覧 */
+  roles: z.array(z.object({
+    /** ロールID */
+    id: z.string(),
+    /** ロール名 */
+    name: z.string(),
+    /** ロールの色（16進数） */
+    color: z.string(),
+    /** ロールの色（数値） */
+    colorValue: z.number(),
+    /** ホイスト（別表示）されるか */
+    hoist: z.boolean(),
+    /** 表示順序の位置 */
+    position: z.number(),
+    /** ロールの権限（ビットフラグ） */
+    permissions: z.string(),
+    /** 管理者権限を持つか */
+    isAdmin: z.boolean(),
+    /** 管理ロールか（Bot、統合など） */
+    managed: z.boolean(),
+    /** メンション可能か */
+    mentionable: z.boolean(),
+    /** ロールタグ（詳細情報が有効な場合） */
+    tags: z.object({
+      /** ボット専用ロールか */
+      isBot: z.boolean(),
+      /** 統合ロールか */
+      isIntegration: z.boolean(),
+      /** プレミアムサブスクライバー専用か */
+      isPremiumSubscriber: z.boolean(),
+      /** ギルドコネクション専用か */
+      isGuildConnections: z.boolean(),
+      /** 購入可能か */
+      isAvailableForPurchase: z.boolean()
+    }).optional(),
+    /** アイコンURL（詳細情報が有効な場合） */
+    iconUrl: z.string().nullable().optional(),
+    /** Unicode絵文字（詳細情報が有効な場合） */
+    unicodeEmoji: z.string().nullable().optional()
+  })),
+  /** 総ロール数 */
+  totalRoleCount: z.number(),
+  /** フィルター適用後のロール数 */
+  filteredRoleCount: z.number(),
+  /** 管理者ロール数 */
+  adminRoleCount: z.number(),
+  /** 管理ロール数 */
+  managedRoleCount: z.number()
+});
+
+export type GetMemberRolesOutput = z.infer<typeof GetMemberRolesOutputSchema>;
+
+/**
+ * 特定のDiscordサーバーメンバーのロール一覧を取得
+ */
+export async function getMemberRoles(
+  discordClient: DiscordClient,
+  input: GetMemberRolesInput
+): Promise<GetMemberRolesOutput> {
+  try {
+    // メンバー情報とサーバーロール一覧を並行取得
+    const [member, allRoles] = await Promise.all([
+      discordClient.getGuildMember(input.guildId, input.userId),
+      discordClient.getGuildRoles(input.guildId)
+    ]);
+
+    // メンバーが持っているロールのみをフィルタリング
+    let memberRoles = allRoles.filter(role => member.roles.includes(role.id));
+
+    // フィルター処理
+    if (input.adminOnly) {
+      memberRoles = memberRoles.filter(role => {
+        const permissions = BigInt(role.permissions);
+        const adminPermission = BigInt('8'); // ADMINISTRATOR permission
+        return (permissions & adminPermission) === adminPermission;
+      });
+    }
+
+    if (input.excludeManaged) {
+      memberRoles = memberRoles.filter(role => !role.managed);
+    }
+
+    // メンバー情報を処理
+    const user = member.user || {
+      id: input.userId,
+      username: 'Unknown User',
+      discriminator: '0000',
+      avatar: null
+    };
+
+    const memberInfo = {
+      id: user.id,
+      username: user.username,
+      discriminator: user.discriminator,
+      globalName: user.global_name || null,
+      nickname: member.nick || null,
+      avatarUrl: user.avatar
+        ? `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`
+        : null,
+      isBot: user.bot || false,
+      joinedAt: member.joined_at,
+      premiumSince: member.premium_since || null
+    };
+
+    // ロール情報を処理
+    const processedRoles = memberRoles.map(role => {
+      // 色を16進数に変換
+      const colorHex = role.color.toString(16).padStart(6, '0');
+      const color = role.color === 0 ? '#000000' : `#${colorHex}`;
+
+      // 管理者権限チェック
+      const permissions = BigInt(role.permissions);
+      const adminPermission = BigInt('8');
+      const isAdmin = (permissions & adminPermission) === adminPermission;
+
+      const roleInfo: any = {
+        id: role.id,
+        name: role.name,
+        color,
+        colorValue: role.color,
+        hoist: role.hoist,
+        position: role.position,
+        permissions: role.permissions,
+        isAdmin,
+        managed: role.managed,
+        mentionable: role.mentionable
+      };
+
+      // 詳細情報が要求された場合
+      if (input.includeDetails) {
+        if (role.tags) {
+          roleInfo.tags = {
+            isBot: !!role.tags.bot_id,
+            isIntegration: !!role.tags.integration_id,
+            isPremiumSubscriber: role.tags.premium_subscriber !== undefined,
+            isGuildConnections: role.tags.guild_connections !== undefined,
+            isAvailableForPurchase: role.tags.available_for_purchase !== undefined
+          };
+        }
+
+        if (role.icon) {
+          roleInfo.iconUrl = `https://cdn.discordapp.com/role-icons/${role.id}/${role.icon}.png`;
+        } else {
+          roleInfo.iconUrl = null;
+        }
+
+        roleInfo.unicodeEmoji = role.unicode_emoji || null;
+      }
+
+      return roleInfo;
+    });
+
+    // 統計情報を計算
+    const adminRoleCount = memberRoles.filter(role => {
+      const permissions = BigInt(role.permissions);
+      const adminPermission = BigInt('8');
+      return (permissions & adminPermission) === adminPermission;
+    }).length;
+
+    const managedRoleCount = memberRoles.filter(role => role.managed).length;
+
+    return {
+      member: memberInfo,
+      roles: processedRoles,
+      totalRoleCount: member.roles.length,
+      filteredRoleCount: processedRoles.length,
+      adminRoleCount,
+      managedRoleCount
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'メンバーロールの取得中に不明なエラーが発生しました';
+    throw new Error(`メンバーロールの取得に失敗しました: ${errorMessage}`);
+  }
+}


### PR DESCRIPTION
## Summary
- get_member_roles ツールの実装
- 特定メンバーのロール一覧取得機能
- 管理者権限フィルタリング機能
- 管理ロール除外機能
- 詳細情報取得機能（タグ、アイコン、絵文字）
- メンバー情報とロール情報の並行取得による高速化

## Test plan
- [x] ユニットテストの実装と実行
- [x] TypeScript型チェック
- [x] ESLint検証
- [x] ビルド確認
- [x] タスクリストの更新

🤖 Generated with [Claude Code](https://claude.ai/code)